### PR TITLE
Update atari_rom.vhd

### DIFF
--- a/Source/QuartusProject/Max10_SD/atari_rom.vhd
+++ b/Source/QuartusProject/Max10_SD/atari_rom.vhd
@@ -204,7 +204,7 @@ BEGIN
 	CART_RD5 <= high_bank_enabled;
 	CART_RD4 <= low_bank_enabled;
 	
-	CART_DATA <= data_out when (CART_S5 = '0' or CART_S4 = '0' or (CART_CTL = '0' and (sic_read_d500 or xex_read_d500)))
+	CART_DATA <= data_out when ((CART_S5 = '0' and CART_RD5 = '1') or (CART_S4 = '0' and CART_RD4 = '1') or (CART_CTL = '0' and (sic_read_d500 or xex_read_d500)))
 					 else "ZZZZZZZZ";
 	
 	sram_cart_bus_enabled <= '0' when cart_type = CART_TYPE_BOOT else '1';


### PR DESCRIPTION
I have found a compatibility problem with the Ultimate Cart and the classic Atari 800 (non-XL/XE) computer.
 ﻿
When using the Ultimate Cart on this machine, any memory access to non-enabled ROM area will nevertheless cause a bus contention with the underlying RAM at $8000-$bfff.
 
The reason being that the Ultimate Cart relies on the Atari XL/XE MMU behavior that /S4,/S5 is disabled when RD4,RD5 is kept low.
 ﻿
But unfortunately, on the Atari 800, /S4 & /S5 are always active. Only the RAM is not mapped when RD4, RD5 is driven high...
 ﻿﻿﻿﻿

FPGA always drives data bus drivers when /S4 or /S5 is pulled low.

It should mask the read data according to the state of RD4 & RD5:


https://atariage.com/forums/topic/241888-ultimate-cart-sd-multicart-technical-thread/?do=findComment&comment=4266797